### PR TITLE
MessageBird overlap with “Go to top” button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -272,8 +272,8 @@ label {
 
 #scrollUp {
   position: absolute;
-  right: 15px;
-  bottom: 40px;
+  right: 10px;
+  bottom: 10px;
   background: #000;
   width: 40px;
   height: 40px;


### PR DESCRIPTION
I don’t see either of these two icons in the Figma, so I’m not sure where I should move the ‘scrolltotop’ icon to.
Also, the MessageBird doesn’t show up when I run it locally so I’m not sure if my changes actually fix it.

I could just move the ScrollToTop Icon above the MessageBird, but I figured it might be cleaner if it’s below it.